### PR TITLE
fix: traffic api workflows

### DIFF
--- a/.github/workflows/traffic.yaml
+++ b/.github/workflows/traffic.yaml
@@ -1,9 +1,12 @@
-name: Traffic Views
+name: traffic
 
 on:
   schedule:
     - cron: "0 * * * *" # every hour
   workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -19,10 +22,47 @@ jobs:
             https://api.github.com/repos/${{ github.repository }}/traffic/views \
             > traffic.json
 
-      - name: Publish to gh-pages
+      - name: Create index.html
+        run: |
+          cat > index.html << 'EOF'
+          <!DOCTYPE html>
+          <html>
+          <head>
+              <title>Leo Repository Traffic</title>
+              <meta charset="UTF-8">
+              <style>
+                  body { font-family: Arial, sans-serif; margin: 40px; }
+                  .container { max-width: 800px; margin: 0 auto; }
+                  pre { background: #f4f4f4; padding: 20px; border-radius: 5px; overflow-x: auto; }
+              </style>
+          </head>
+          <body>
+              <div class="container">
+                  <h1>Leo Repository Traffic Data</h1>
+                  <p>Last updated: <span id="lastUpdate"></span></p>
+                  <h2>Raw Traffic Data:</h2>
+                  <pre id="trafficData">Loading...</pre>
+              </div>
+
+              <script>
+                  document.getElementById('lastUpdate').textContent = new Date().toLocaleString();
+
+                  fetch('./traffic.json')
+                      .then(response => response.json())
+                      .then(data => {
+                          document.getElementById('trafficData').textContent = JSON.stringify(data, null, 2);
+                      })
+                      .catch(error => {
+                          document.getElementById('trafficData').textContent = 'Error loading traffic data: ' + error;
+                      });
+              </script>
+          </body>
+          </html>
+          EOF
+
+      - name: Publish to traffic-pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./
-          publish_branch: gh-pages
-          keep_history: true
+          publish_branch: traffic-pages

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
       - id: check-merge-conflict
       - id: check-yaml
       - id: detect-private-key
+      - id: detect-aws-credentials
       - id: mixed-line-ending
       - id: end-of-file-fixer
       - id: trailing-whitespace

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ define run_with_venv
 	fi
 endef
 
-.PHONY: pre-commit format-check lint-check format-fix lint-fix ci install setup-and-check check
+.PHONY: pre-commit format-check lint-check format-fix lint-fix ci install setup-and-ci check
 
 # Pre-commit
 pre-commit:
@@ -50,7 +50,7 @@ install:
 	$(call run_with_venv,cd app/online_sys && uv pip install -e .)
 
 # Setup everything and run checks
-setup-and-check: install ci
+setup-and-ci: install ci
 
 # Run full workflow
 check: pre-commit ci

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <div align="center">
     <h1>Leo</h1>
   <p>
-    <img src="https://img.shields.io/github/issues/tuanlda78202/leo?color=dc143c" alt="Issues">
+    <img src="https://img.shields.io/github/issues/tuanlda78202/leo?color=AD0E0E" alt="Issues">
     <img src="https://img.shields.io/github/issues-pr/tuanlda78202/leo" alt="Pull Requests">
     <img src="https://img.shields.io/github/actions/workflow/status/tuanlda78202/leo/pre-commit-checks.yaml?branch=main&label=pre-commit&logo=pre-commit&logoColor=white" alt="Pre-commit Status">
     <img src="https://img.shields.io/github/actions/workflow/status/tuanlda78202/leo/ci.yaml?branch=main&label=ci&logo=github" alt="CI Status">
     <img src="https://img.shields.io/github/last-commit/tuanlda78202/leo" alt="Last Commit">
-    <img src="https://img.shields.io/badge/dynamic/json?label=Views&url=https://tuanlda78202.github.io/leo/traffic.json&query=count" alt="GitHub Views">
+    <img src="https://img.shields.io/badge/dynamic/json?color=AD0E0E&label=Views&url=https://raw.githubusercontent.com/tuanlda78202/leo/traffic/traffic.json&query=count" alt="GitHub Views">
   </p>
 
   <p align="center">


### PR DESCRIPTION
This PR introduces updates to the GitHub Actions workflow, pre-commit configuration, Makefile, and README, focusing on improving repository automation, code quality checks, and documentation. The most significant changes include modifying the traffic workflow to generate and publish an HTML report, adding a new pre-commit hook, and renaming a Makefile target for clarity.

### Workflow and automation updates:
* [`.github/workflows/traffic.yaml`](diffhunk://#diff-9ac5945f2096de716b3e6a4d6880e08fa545aafe6fb718829f7c6a548fee4100L1-R10): Updated the traffic workflow to generate an HTML report (`index.html`) displaying repository traffic data and publish it to a new branch `traffic-pages`. Permissions were also updated to allow writing contents. [[1]](diffhunk://#diff-9ac5945f2096de716b3e6a4d6880e08fa545aafe6fb718829f7c6a548fee4100L1-R10) [[2]](diffhunk://#diff-9ac5945f2096de716b3e6a4d6880e08fa545aafe6fb718829f7c6a548fee4100L22-R68)

### Pre-commit configuration:
* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R11): Added a new pre-commit hook `detect-aws-credentials` to identify and prevent accidental inclusion of AWS credentials.

### Build system improvements:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L15-R15): Renamed the `setup-and-check` target to `setup-and-ci` for better clarity, reflecting its purpose of setting up the environment and running CI checks. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L15-R15) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L53-R53)

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R9): Updated the color of the "Issues" badge and changed the URL for the "Views" badge to point to the new `traffic-pages` branch.