### PR TITLE
ci: add gitleaks workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: ci
+name: CI
 
 on:
   push:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Generic hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=4096"]
@@ -15,7 +15,7 @@ repos:
 
   # Markdown linter
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.38.0
+    rev: v0.45.0
     hooks:
       - id: markdownlint
         args:
@@ -27,6 +27,12 @@ repos:
 
   # Typos
   - repo: https://github.com/crate-ci/typos
-    rev: v1.16.24
+    rev: v1
     hooks:
       - id: typos
+
+  # Gitleaks
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.27.2
+    hooks:
+      - id: gitleaks

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 /.github/ @tuanlda78202
 /app/ @tuanlda78202
+/docs/ @tuanlda78202

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 <div align="center">
     <h1>Leo</h1>
-  <p>
+  <!-- <p>
     <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-lightgrey.svg" alt="License: MIT"></a>
     <img src="https://img.shields.io/github/issues/tuanlda78202/leo?color=AD0E0E&label=Issues" alt="Issues">
     <img src="https://img.shields.io/github/issues-pr/tuanlda78202/leo?&label=PRs" alt="Pull Requests">
     <img src="https://img.shields.io/badge/dynamic/json?color=AD0E0E&label=Views&url=https://raw.githubusercontent.com/tuanlda78202/leo/gh-pages/traffic.json&query=count" alt="GitHub Views">
-  </p>
+  </p> -->
   <p>
+    <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-lightgrey.svg" alt="License: MIT"></a>
     <img src="https://img.shields.io/github/actions/workflow/status/tuanlda78202/leo/pre-commit-checks.yaml?branch=main&label=pre-commit&logo=pre-commit&logoColor=white" alt="Pre-commit Status">
     <img src="https://img.shields.io/github/actions/workflow/status/tuanlda78202/leo/ci.yaml?branch=main&label=CI&logo=github" alt="CI Status">
     <img src="https://img.shields.io/github/actions/workflow/status/tuanlda78202/leo/github-code-scanning%2Fcodeql?branch=main&label=CodeQL&logo=github" alt="CodeQL">


### PR DESCRIPTION
* Support `gitleaks` action workflows
  * [`Gitleaks`](https://github.com/gitleaks/gitleaks) is a tool for detecting secrets like passwords, API keys, and tokens in git repos, files, and whatever else you wanna throw at it via stdin

    ```
    ➜  ~/code(master) gitleaks git -v
    
        ○
        │╲
        │ ○
        ○ ░
        ░    gitleaks
    
    
    Finding:     "export BUNDLE_ENTERPRISE__CONTRIBSYS__COM=cafebabe:deadbeef",
    Secret:      cafebabe:deadbeef
    RuleID:      sidekiq-secret
    Entropy:     2.609850
    File:        cmd/generate/config/rules/sidekiq.go
    Line:        23
    Commit:      cd5226711335c68be1e720b318b7bc3135a30eb2
    Author:      John
    Email:       john@users.noreply.github.com
    Date:        2022-08-03T12:31:40Z
    Fingerprint: cd5226711335c68be1e720b318b7bc3135a30eb2:cmd/generate/config/rules/sidekiq.go:sidekiq-secret:23
    ```